### PR TITLE
Fix bug in AddNewPopup tempData initialization

### DIFF
--- a/src/components/AddNewPopup.vue
+++ b/src/components/AddNewPopup.vue
@@ -36,7 +36,7 @@ export default {
   components: { Codemirror },
   data() {
     return {
-      tempData: Object,
+      tempData: null,
       dataIsValid: false,
       statusMessage: '',
       statusType: '',


### PR DESCRIPTION
## Summary
- set `tempData` to `null` so it doesn't default to the global `Object`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffbbc37888323866540ef3bae962f